### PR TITLE
Upgrade ClickHouse container to 25.12.1.649

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -64,7 +64,7 @@ func CreateClickHouseContainer(ctx context.Context, settings config.Settings) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to create certs: %w", err)
 	}
-	clickHouseContainer, err := chmodule.Run(ctx, "clickhouse/clickhouse-server:24.12.1.1614-alpine",
+	clickHouseContainer, err := chmodule.Run(ctx, "clickhouse/clickhouse-server:25.12.1.649-alpine",
 		chmodule.WithDatabase(settings.Database),
 		chmodule.WithUsername(settings.User),
 		chmodule.WithPassword(settings.Password),


### PR DESCRIPTION
On the cloud, SELECT version() gives 25.12.1.1497.